### PR TITLE
Fix syntax error in style.js

### DIFF
--- a/App/Views/Stocks/Elements/StockCell/style.js
+++ b/App/Views/Stocks/Elements/StockCell/style.js
@@ -29,7 +29,6 @@ module.exports = StyleSheet.create({
   },
   symbolText: {
     fontSize: 16,
-    marginBottom: 10,
     color: 'white',
     textAlign: 'left',
     marginTop: 10,
@@ -41,7 +40,6 @@ module.exports = StyleSheet.create({
   },
   priceText: {
     fontSize: 16,
-    marginBottom: 10,
     color: 'white',
     textAlign: 'right',
     marginTop: 10,


### PR DESCRIPTION
Was getting the error "Attempted to redefined property 'marginBottom'."  It was being defined twice. Removing fixed.
![screenshot 2015-10-27 15 44 08](https://cloud.githubusercontent.com/assets/1510005/10748425/d9e4bf22-7cc4-11e5-8a4b-aef8b285660e.png)